### PR TITLE
Added Qt styling in settings menu

### DIFF
--- a/src/editor/EditorWindow.h
+++ b/src/editor/EditorWindow.h
@@ -42,8 +42,10 @@ class EditorWindow : public QMainWindow {
   void hostDirectly(std::optional<QString> filename, QHostAddress host,
                     int port, std::optional<QString> recording_save_file,
                     QString username);
+
  private slots:
   void connectToHost();
+  void restart();
 
  private:
   void Host(HostSetting host_setting);

--- a/src/editor/EditorWindow.ui
+++ b/src/editor/EditorWindow.ui
@@ -24,7 +24,7 @@
      <x>0</x>
      <y>0</y>
      <width>863</width>
-     <height>27</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -188,6 +188,11 @@
   <action name="actionClear_Settings">
    <property name="text">
     <string>Clear Settings</string>
+   </property>
+  </action>
+  <action name="actionRestart">
+   <property name="text">
+    <string>Restart</string>
    </property>
   </action>
  </widget>

--- a/src/editor/Settings.h
+++ b/src/editor/Settings.h
@@ -8,6 +8,8 @@
 
 #include "pxtone/pxtnEvelist.h"
 
+static QFile styleFile(QCoreApplication::applicationDirPath() + QString(".style")); // not a QSetting
+
 const extern QString WOICE_DIR_KEY;
 const extern QString BUFFER_LENGTH_KEY;
 const extern double DEFAULT_BUFFER_LENGTH;
@@ -24,9 +26,6 @@ const extern QString SAVE_RECORDING_ENABLED_KEY;
 const extern QString HOSTING_ENABLED_KEY;
 
 const extern QString CONNECT_SERVER_KEY;
-
-static QFile styleFile(QCoreApplication::applicationDirPath() + QString(".style"));
-
 
 
 namespace Settings {

--- a/src/editor/Settings.h
+++ b/src/editor/Settings.h
@@ -3,6 +3,8 @@
 
 #include <QSettings>
 #include <QString>
+#include <QFile>
+#include <QCoreApplication>
 
 #include "pxtone/pxtnEvelist.h"
 
@@ -22,6 +24,10 @@ const extern QString SAVE_RECORDING_ENABLED_KEY;
 const extern QString HOSTING_ENABLED_KEY;
 
 const extern QString CONNECT_SERVER_KEY;
+
+static QFile styleFile(QCoreApplication::applicationDirPath() + QString(".style"));
+
+
 
 namespace Settings {
 namespace TextSize {

--- a/src/editor/SettingsDialog.h
+++ b/src/editor/SettingsDialog.h
@@ -23,6 +23,10 @@ class SettingsDialog : public QDialog {
   void showEvent(QShowEvent *event) override;
   const MidiWrapper *m_midi_wrapper;
   Ui::SettingsDialog *ui;
+
+ private slots:
+  void styleTickBox();
+
 };
 
 #endif  // SETTINGSDIALOG_H

--- a/src/editor/SettingsDialog.h
+++ b/src/editor/SettingsDialog.h
@@ -13,11 +13,16 @@ class SettingsDialog : public QDialog {
 
  public:
   explicit SettingsDialog(const MidiWrapper *, QWidget *parent = nullptr);
-  void apply();
   ~SettingsDialog();
+
+  void apply();
+
+  bool openingCustomTheme;
+  int openingSelectedThemeIndex;
 
  signals:
   void midiPortSelected(int port_no);
+  void restartRequest();
 
  private:
   void showEvent(QShowEvent *event) override;

--- a/src/editor/SettingsDialog.ui
+++ b/src/editor/SettingsDialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">

--- a/src/editor/SettingsDialog.ui
+++ b/src/editor/SettingsDialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -140,7 +140,7 @@
        <item>
         <widget class="QCheckBox" name="customStyleCheck">
          <property name="text">
-          <string>Use custom style (must restart)</string>
+          <string>Use custom style</string>
          </property>
         </widget>
        </item>
@@ -182,6 +182,16 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Changes to style will take effect after restarting.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/editor/SettingsDialog.ui
+++ b/src/editor/SettingsDialog.ui
@@ -25,13 +25,6 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <widget class="QCheckBox" name="customStyleCheck">
-         <property name="text">
-          <string>Use custom style (must restart)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="chordPreviewCheck">
          <property name="text">
           <string>Preview with all units</string>
@@ -126,6 +119,59 @@
        </item>
        <item>
         <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_3">
+      <attribute name="title">
+       <string>Style</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QCheckBox" name="customStyleCheck">
+         <property name="text">
+          <string>Use custom style (must restart)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>15</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Style</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="styleCombo"/>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,12 @@ int main(int argc, char *argv[]) {
     qApp->setPalette(palette);
     qApp->setStyleSheet(stylesheet);
   }
+  if (!Settings::CustomStyle::get())
+  {
+      styleFile.open(QFile::ReadOnly);
+      a.setStyle(QStyleFactory::create(styleFile.readAll()));
+      styleFile.close();
+ }
 
   a.setApplicationVersion(Settings::Version::string());
   QCommandLineParser parser;


### PR DESCRIPTION
### Changes
Moved "Use custom style (must restart)" tick box from "General" tab into the new "Styles" tab, which also contains a combo box housing the available Qt styles (`QStyleFactory::keys()`).

The style information is kept in a distinctive file rather than a QSettings key (`.style` in the same directory as the executable) because some styles have a tendency to crash the program. In the event of a crash, you would not be unable to change any QSettings, whereas the modification/deletion of the .style file will fix the problem entirely.

I decided to require a restart for the changing of style (like the existing style toggle did). Although it is possible to hotswap Qt styles, in my experience, it leaves a lot of inconsistencies that can only be solved by a repaint of the MainWindow (i.e. a restart).
 
Below: Screenshot of modified Settings window.

![image](https://user-images.githubusercontent.com/36348486/112406947-c91fdd80-8cda-11eb-8993-840dbb4f4fde.png)

Below: Screenshot of ptcollab with the Breeze style. 

![image](https://user-images.githubusercontent.com/36348486/112407568-f1f4a280-8cdb-11eb-9d9b-607e13744af6.png)

