### PR TITLE
fix: crash on open Settings dialog if no MIDI-in port available

### DIFF
--- a/src/editor/MidiWrapper.cpp
+++ b/src/editor/MidiWrapper.cpp
@@ -30,7 +30,7 @@ QStringList MidiWrapper::ports() const {
 }
 
 std::optional<int> MidiWrapper::currentPort() const {
-  if (m_in->isPortOpen()) return m_current_port;
+  if (m_in && m_in->isPortOpen()) return m_current_port;
   return std::nullopt;
 }
 


### PR DESCRIPTION
When no midi-in port available, the program will crash if I trying to open the settings dialog. This patch fixes this issue by checking if `m_in` is null.