### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,75 @@
+name: Build-Test
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  QT_VERSION: 5.15.2
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        config:
+          - { name: "Windows", os: windows-latest, make: nmake }
+          - { name: "macOS", os: macos-latest, make: "make -j2" }
+          - { name: "Ubuntu", os: ubuntu-latest, make: "make -j2" }
+      fail-fast: false
+
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Qt5
+        uses: jurplel/install-qt-action@v2
+        with:
+          version: ${{ env.QT_VERSION }}
+          modules: 'qttools qtmultimedia'
+
+      - name: Setup MSVC Toolchain [Windows]
+        if: ${{ runner.os == 'Windows' }}
+        uses: seanmiddleditch/gha-setup-vsdevenv@v3
+
+      - name: Install Dependencies [macOS]
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          export HOMEBREW_NO_INSTALL_CLEANUP=1
+          brew update
+          brew install libvorbis rtmidi
+          brew upgrade libogg
+
+      - name: Install Dependencies [Linux]
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt update
+          sudo apt install libogg-dev libvorbis-dev librtmidi-dev
+
+      - name: Configure
+        run: |
+          qmake ptcollab.pro \
+            PREFIX=$PWD/target \
+            CONFIG+=release CONFIG-=debug
+          ${{ matrix.config.make }} qmake_all
+
+          # /usr/bin/link interferes with MSVC link binary
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            rm -f /usr/bin/link
+          fi
+
+      - name: Build
+        run: |
+          ${{ matrix.config.make }}
+
+      - name: Install
+        run: |
+          ${{ matrix.config.make }} install

--- a/src/editor.pro
+++ b/src/editor.pro
@@ -8,8 +8,7 @@ TARGET = ptcollab
 # Including /usr/include/rtmidi since in some dists RtMidi.h is in root dir and
 # others it's in a subdir
 INCLUDEPATH += . /usr/include/rtmidi
-win32:INCLUDEPATH += ../deps/include
-macx:INCLUDEPATH += ../deps/include
+win32|macx:INCLUDEPATH += ../deps/include
 QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.14
 
 !win32:LIBS += -logg -lvorbisfile

--- a/src/protocol/SerializeVariant.h
+++ b/src/protocol/SerializeVariant.h
@@ -3,6 +3,7 @@
 
 #include <QDataStream>
 #include <variant>
+#include <stdexcept>
 
 // Some scourging the internet to find a way to deserialize a variant b/c
 // variants work well for deduping code for the msg protocol


### PR DESCRIPTION
Adds build tests for Windows, macOS and Ubuntu.

The change in src/protocol/SerializeVariant.h was required to fix a missing reference to std::runtime_error with VS 2019.

Tests running successfully on my fork: https://github.com/OPNA2608/ptcollab/pull/1, https://github.com/OPNA2608/ptcollab/actions/runs/922754114