### PR TITLE
Add tests for dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,12 +59,13 @@ jobs:
           qmake ptcollab.pro \
             PREFIX=$PWD/target \
             CONFIG+=release CONFIG-=debug
-          ${{ matrix.config.make }} qmake_all
 
           # /usr/bin/link interferes with MSVC link binary
           if [ "${{ runner.os }}" == "Windows" ]; then
             rm -f /usr/bin/link
           fi
+
+          ${{ matrix.config.make }} qmake_all
 
       - name: Build
         run: |

--- a/qmake/config.tests/common.pri
+++ b/qmake/config.tests/common.pri
@@ -1,0 +1,3 @@
+TARGET = test
+SOURCES = $$PWD/../test.cpp
+CONFIG += cmdline

--- a/qmake/config.tests/libogg_static/libogg_static.pro
+++ b/qmake/config.tests/libogg_static/libogg_static.pro
@@ -1,0 +1,10 @@
+include("../common.pri")
+
+INCLUDEPATH += . /usr/local/include/rtmidi /usr/local/include /usr/include/rtmidi /usr/include
+win32|macx:INCLUDEPATH += ../../../deps/include
+
+win32:LIBS += -L"$$PWD/../../../deps/lib" -L"$$PWD/../../deps/lib"
+macx:LIBS += -L/usr/local/lib
+
+DEFINES += OGG
+LIBS += -llibogg_static

--- a/qmake/config.tests/libvorbisfile/libvorbisfile.pro
+++ b/qmake/config.tests/libvorbisfile/libvorbisfile.pro
@@ -1,0 +1,10 @@
+include("../common.pri")
+
+INCLUDEPATH += . /usr/local/include/rtmidi /usr/local/include /usr/include/rtmidi /usr/include
+win32|macx:INCLUDEPATH += ../../../deps/include
+
+win32:LIBS += -L"$$PWD/../../../deps/lib" -L"$$PWD/../../deps/lib"
+macx:LIBS += -L/usr/local/lib
+
+DEFINES += VORBISFILE
+LIBS += -llibvorbisfile

--- a/qmake/config.tests/ogg_lib/ogg_lib.pro
+++ b/qmake/config.tests/ogg_lib/ogg_lib.pro
@@ -1,0 +1,10 @@
+include("../common.pri")
+
+INCLUDEPATH += . /usr/local/include/rtmidi /usr/local/include /usr/include/rtmidi /usr/include
+win32|macx:INCLUDEPATH += ../../../deps/include
+
+win32:LIBS += -L"$$PWD/../../../deps/lib" -L"$$PWD/../../deps/lib"
+macx:LIBS += -L/usr/local/lib
+
+DEFINES += OGG
+LIBS += -logg

--- a/qmake/config.tests/ogg_pkgconfig/ogg_pkgconfig.pro
+++ b/qmake/config.tests/ogg_pkgconfig/ogg_pkgconfig.pro
@@ -1,0 +1,5 @@
+include("../common.pri")
+
+DEFINES += OGG
+CONFIG += link_pkgconfig
+PKGCONFIG += ogg

--- a/qmake/config.tests/rtmidi_lib/rtmidi_lib.pro
+++ b/qmake/config.tests/rtmidi_lib/rtmidi_lib.pro
@@ -1,0 +1,10 @@
+include("../common.pri")
+
+INCLUDEPATH += . /usr/local/include/rtmidi /usr/local/include /usr/include/rtmidi /usr/include
+win32|macx:INCLUDEPATH += ../../../deps/include
+
+win32:LIBS += -L"$$PWD/../../../deps/lib" -L"$$PWD/../../deps/lib"
+macx:LIBS += -L/usr/local/lib
+
+DEFINES += RTMIDI
+LIBS += -lrtmidi

--- a/qmake/config.tests/rtmidi_pkgconfig/rtmidi_pkgconfig.pro
+++ b/qmake/config.tests/rtmidi_pkgconfig/rtmidi_pkgconfig.pro
@@ -1,0 +1,5 @@
+include("../common.pri")
+
+DEFINES += RTMIDI
+CONFIG += link_pkgconfig
+PKGCONFIG += rtmidi

--- a/qmake/config.tests/vorbisfile_lib/vorbisfile_lib.pro
+++ b/qmake/config.tests/vorbisfile_lib/vorbisfile_lib.pro
@@ -1,0 +1,10 @@
+include("../common.pri")
+
+INCLUDEPATH += . /usr/local/include/rtmidi /usr/local/include /usr/include/rtmidi /usr/include
+win32|macx:INCLUDEPATH += ../../../deps/include
+
+win32:LIBS += -L"$$PWD/../../../deps/lib" -L"$$PWD/../../deps/lib"
+macx:LIBS += -L/usr/local/lib
+
+DEFINES += VORBISFILE
+LIBS += -lvorbisfile

--- a/qmake/config.tests/vorbisfile_pkgconfig/vorbisfile_pkgconfig.pro
+++ b/qmake/config.tests/vorbisfile_pkgconfig/vorbisfile_pkgconfig.pro
@@ -1,0 +1,5 @@
+include("../common.pri")
+
+DEFINES += VORBISFILE
+CONFIG += link_pkgconfig
+PKGCONFIG += vorbisfile

--- a/qmake/findLibrary.pri
+++ b/qmake/findLibrary.pri
@@ -1,0 +1,34 @@
+load(configure)
+
+QMAKE_CONFIG_TESTS_DIR = $$PWD/config.tests
+CONFIG += recheck
+
+defineTest(findLibrary) {
+  # Name of the library when printing QMake messages
+  prettyName = $$1
+
+  # List of test names to execute in order
+  # At least one must succeed if library isRequired, all may fail if !isRequired
+  # If none succeed and library isRequired, errors build with appropriate message
+  testNames_var = $$2
+  testNames = $$eval($$testNames_var)
+
+  # If this library is required by default (i.e. in general or for the target platform)
+  isRequired = $$3
+
+  if(!isEmpty(isRequired):$$isRequired): dependency = "required"
+  else: dependency = "detected"
+
+  for(TEST, testNames) {
+    qtCompileTest($$TEST)
+    if(config_$$TEST) {
+      message("[$$dependency] $$prettyName found & enabled")
+      return(true)
+    }
+  }
+
+  !equals(dependency, "detected") {
+    error("$$prettyName support is $$dependency but all tests failed! Check $$_PRO_FILE_PWD_/config.log for more details!")
+    return(false)
+  }
+}

--- a/qmake/test.cpp
+++ b/qmake/test.cpp
@@ -1,0 +1,12 @@
+#if defined(RTMIDI)
+#include "RtMidi.h"
+#elif defined(OGG)
+#include "ogg/ogg.h"
+#elif defined(VORBISFILE)
+#include "vorbis/vorbisfile.h"
+#endif
+
+int main()
+{
+  return 0;
+}

--- a/src/editor.pro
+++ b/src/editor.pro
@@ -11,16 +11,48 @@ INCLUDEPATH += . /usr/include/rtmidi
 win32|macx:INCLUDEPATH += ../deps/include
 QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.14
 
-!win32:LIBS += -logg -lvorbisfile
-win32:LIBS += -L"$$PWD/../deps/lib" -L"$$PWD/deps/lib" -llibogg_static -llibvorbisfile -lwinmm
+win32:LIBS += -L"$$PWD/../deps/lib" -L"$$PWD/deps/lib"
 macx:LIBS += -L/usr/local/lib
 
-unix:!macx {
-    CONFIG += link_pkgconfig
-    PKGCONFIG += rtmidi
-} else {
-    LIBS += -lrtmidi
+pkgconfig_required = false
+
+include("../qmake/findLibrary.pri")
+
+win32 {
+    message("[default] Adding Windows Multimedia")
+    LIBS += -lwinmm
 }
+
+tests_ogg = ogg_pkgconfig ogg_lib libogg_static
+if(findLibrary("libogg(_static)", tests_ogg, true)) {
+    config_ogg_pkgconfig {
+        pkgconfig_required = true
+        PKGCONFIG += ogg
+    }
+    config_ogg_lib: LIBS += -logg
+    config_libogg_static: LIBS += -llibogg_static
+}
+
+tests_vorbisfile = vorbisfile_pkgconfig vorbisfile_lib libvorbisfile
+if(findLibrary("libvorbisfile", tests_vorbisfile, true)) {
+    config_vorbisfile_pkgconfig {
+        pkgconfig_required = true
+        PKGCONFIG += vorbisfile
+    }
+    config_vorbisfile_lib: LIBS += -lvorbisfile
+    config_libvorbisfile: LIBS += -llibvorbisfile
+}
+
+tests_rtmidi = rtmidi_pkgconfig rtmidi_lib
+if(findLibrary("RtMidi", tests_rtmidi, true)) {
+    config_rtmidi_pkgconfig {
+        pkgconfig_required = true
+        PKGCONFIG += rtmidi
+    }
+    config_rtmidi_lib: LIBS += -lrtmidi
+}
+
+equals(pkgconfig_required, "true"): CONFIG += link_pkgconfig
 
 QT       += core gui
 


### PR DESCRIPTION
Uses QMake's test functionalities to check for libogg, vorbisfile and rtmidi libraries, preferring pkg-config over direct libraries.