### PR TITLE
Tracker-esque recording mode

### DIFF
--- a/src/editor/EditorWindow.cpp
+++ b/src/editor/EditorWindow.cpp
@@ -483,7 +483,11 @@ void EditorWindow::keyPressEvent(QKeyEvent *event) {
       }
       break;
     case Qt::Key::Key_R:
-      rKeyStateChanged(true);
+      if (event->modifiers() & Qt::ControlModifier) {
+        Settings::EditorRecording::set(!Settings::EditorRecording::get());
+      } else {
+        rKeyStateChanged(true);
+      }
       break;
     case Qt::Key_S:
       if (!(event->modifiers() & Qt::ControlModifier))
@@ -698,14 +702,16 @@ void EditorWindow::recordInput(const Input::Event::Event &e) {
           [this](const Input::Event::On &e) {
             // TODO: handle repeat
             int start = m_moo_clock->nowNoWrap();
-            m_client->changeEditState(
-                [&](EditState &state) {
-                  if (state.m_input_state.has_value()) {
-                    applyOn(state.m_input_state.value(), start, m_client);
-                  }
-                  state.m_input_state = Input::State::On{start, e};
-                },
-                false);
+            if (Settings::EditorRecording::get()) {
+              m_client->changeEditState(
+                  [&](EditState &state) {
+                    if (state.m_input_state.has_value()) {
+                      applyOn(state.m_input_state.value(), start, m_client);
+                    }
+                    state.m_input_state = Input::State::On{start, e};
+                  },
+                  false);
+            }
             auto maybe_unit_no = m_client->unitIdMap().idToNo(
                 m_client->editState().m_current_unit_id);
             if (maybe_unit_no != std::nullopt) {
@@ -719,7 +725,8 @@ void EditorWindow::recordInput(const Input::Event::Event &e) {
                   e.vel, m_client->audioState()->bufferSize(), chordPreview,
                   this);
             }
-            if (Settings::AutoAdvance::get() && !m_client->isPlaying())
+            if (Settings::AutoAdvance::get() &&
+                Settings::EditorRecording::get() && !m_client->isPlaying())
               recordInput(Input::Event::Skip{1});
           },
           [this](const Input::Event::Off &e) {

--- a/src/editor/EditorWindow.h
+++ b/src/editor/EditorWindow.h
@@ -27,7 +27,6 @@
 #include "sidemenu/UnitListModel.h"
 #include "views/KeyboardView.h"
 #include "views/MeasureView.h"
-#include "views/ViewHelper.h"
 
 QT_BEGIN_NAMESPACE
 namespace Ui {

--- a/src/editor/EditorWindow.h
+++ b/src/editor/EditorWindow.h
@@ -70,7 +70,7 @@ class EditorWindow : public QMainWindow {
   std::optional<QString> m_filename;
   ConnectionStatusLabel* m_connection_status;
   QLabel *m_fps_status, *m_ping_status;
-  bool m_modified, m_modified_autosave, m_recording;
+  bool m_modified, m_modified_autosave;
   int m_autosave_counter;
   QTimer* m_autosave_timer;
   QString m_autosave_filename;

--- a/src/editor/EditorWindow.h
+++ b/src/editor/EditorWindow.h
@@ -27,6 +27,7 @@
 #include "sidemenu/UnitListModel.h"
 #include "views/KeyboardView.h"
 #include "views/MeasureView.h"
+#include "views/ViewHelper.h"
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -69,7 +70,7 @@ class EditorWindow : public QMainWindow {
   std::optional<QString> m_filename;
   ConnectionStatusLabel* m_connection_status;
   QLabel *m_fps_status, *m_ping_status;
-  bool m_modified, m_modified_autosave;
+  bool m_modified, m_modified_autosave, m_recording;
   int m_autosave_counter;
   QTimer* m_autosave_timer;
   QString m_autosave_filename;

--- a/src/editor/Settings.cpp
+++ b/src/editor/Settings.cpp
@@ -273,4 +273,10 @@ void set(const QList<int> &value) {
 void clear() { return QSettings().remove(KEY); }
 }  // namespace DisplayEdo
 
+namespace EditorRecording {
+const char *KEY = "editor_recording";
+bool get() { return QSettings().value(KEY, true).toBool(); }
+void set(bool value) { return QSettings().setValue(KEY, value); }
+}  // namespace EditorRecording
+
 }  // namespace Settings

--- a/src/editor/Settings.cpp
+++ b/src/editor/Settings.cpp
@@ -281,7 +281,7 @@ void clear() { return QSettings().remove(KEY); }
 
 namespace EditorRecording {
 const char *KEY = "editor_recording";
-bool get() { return QSettings().value(KEY, true).toBool(); }
+bool get() { return QSettings().value(KEY, false).toBool(); }
 void set(bool value) { return QSettings().setValue(KEY, value); }
 }  // namespace EditorRecording
 

--- a/src/editor/Settings.h
+++ b/src/editor/Settings.h
@@ -187,6 +187,10 @@ void set(const QList<int> &);
 void clear();
 }  // namespace DisplayEdo
 
+namespace EditorRecording {
+bool get();
+void set(bool);
+}  // namespace EditorRecording
 }  // namespace Settings
 
 #endif  // SETTINGS_H

--- a/src/editor/StyleEditor.cpp
+++ b/src/editor/StyleEditor.cpp
@@ -291,7 +291,7 @@ bool tryLoadStyle(const QString &styleName) {
   return tryLoadStyle(basedir, styleName);
 }
 
-QColor getPlayheadColor() {
+QColor getActivePlayheadColor() {
   return Settings::EditorRecording::get() ? config.color.PlayheadRecording
                                           : config.color.Playhead;
 };

--- a/src/editor/StyleEditor.cpp
+++ b/src/editor/StyleEditor.cpp
@@ -141,6 +141,8 @@ void loadConfig(const QString &path, Config &c) {
   setConfigColor(styleConfig, c.color.ParamMeasure, "parameters/Measure");
 
   setConfigColor(styleConfig, c.color.Playhead, "views/Playhead");
+  setConfigColor(styleConfig, c.color.PlayheadRecording,
+                 "views/PlayheadRecording");
   setConfigColor(styleConfig, c.color.Cursor, "views/Cursor");
 
   setConfigFont(styleConfig, c.font.EditorFont, "fonts/Editor");
@@ -288,6 +290,11 @@ bool tryLoadStyle(const QString &styleName) {
   QString basedir = it->second;
   return tryLoadStyle(basedir, styleName);
 }
+
+QColor getPlayheadColor() {
+  return Settings::EditorRecording::get() ? config.color.PlayheadRecording
+                                          : config.color.Playhead;
+};
 
 QStringList getStyles() {
   QStringList styles;

--- a/src/editor/StyleEditor.cpp
+++ b/src/editor/StyleEditor.cpp
@@ -291,11 +291,6 @@ bool tryLoadStyle(const QString &styleName) {
   return tryLoadStyle(basedir, styleName);
 }
 
-QColor getActivePlayheadColor() {
-  return Settings::EditorRecording::get() ? config.color.PlayheadRecording
-                                          : config.color.Playhead;
-};
-
 QStringList getStyles() {
   QStringList styles;
   for (const auto &[style, dir] : getStyleMap()) styles.push_back(style);

--- a/src/editor/StyleEditor.h
+++ b/src/editor/StyleEditor.h
@@ -7,6 +7,8 @@
 #include <QPixmap>
 #include <QStringList>
 
+#include "Settings.h"
+
 namespace StyleEditor {
 void initializeStyleDir();
 bool tryLoadStyle(const QString &styleName);
@@ -54,6 +56,7 @@ struct Config {
     QColor ParamMeasure;
 
     QColor Playhead;
+    QColor PlayheadRecording;
     QColor Cursor;
   } color;
 
@@ -64,7 +67,9 @@ struct Config {
 
   static Config empty() { return {}; }
 };
+
 extern const Config &config;
+QColor getPlayheadColor();
 QStringList getStyles();
 }  // namespace StyleEditor
 

--- a/src/editor/StyleEditor.h
+++ b/src/editor/StyleEditor.h
@@ -69,7 +69,7 @@ struct Config {
 };
 
 extern const Config &config;
-QColor getPlayheadColor();
+QColor getActivePlayheadColor();
 QStringList getStyles();
 }  // namespace StyleEditor
 

--- a/src/editor/StyleEditor.h
+++ b/src/editor/StyleEditor.h
@@ -69,7 +69,6 @@ struct Config {
 };
 
 extern const Config &config;
-QColor getActivePlayheadColor();
 QStringList getStyles();
 }  // namespace StyleEditor
 

--- a/src/editor/views/ViewHelper.cpp
+++ b/src/editor/views/ViewHelper.cpp
@@ -43,9 +43,11 @@ void drawPlayhead(QPainter &painter, qint32 x, qint32 height, QColor color,
 
 void drawCurrentPlayerPosition(QPainter &painter, MooClock *moo_clock,
                                int height, qreal clockPerPx, bool drawHead) {
-  QColor color = (moo_clock->this_seek_caught_up() && moo_clock->now() > 0
-                      ? StyleEditor::getActivePlayheadColor()
-                      : makeTranslucent(StyleEditor::getActivePlayheadColor(), 2));
+  QColor color = Settings::EditorRecording::get()
+                     ? StyleEditor::config.color.PlayheadRecording
+                     : StyleEditor::config.color.Playhead;
+  if (!moo_clock->this_seek_caught_up() || moo_clock->now() <= 0)
+    color = makeTranslucent(color, 2);
   const int x = moo_clock->now() / clockPerPx;
   drawPlayhead(painter, x, height, color, drawHead);
 }

--- a/src/editor/views/ViewHelper.cpp
+++ b/src/editor/views/ViewHelper.cpp
@@ -44,8 +44,8 @@ void drawPlayhead(QPainter &painter, qint32 x, qint32 height, QColor color,
 void drawCurrentPlayerPosition(QPainter &painter, MooClock *moo_clock,
                                int height, qreal clockPerPx, bool drawHead) {
   QColor color = (moo_clock->this_seek_caught_up() && moo_clock->now() > 0
-                      ? StyleEditor::config.color.Playhead
-                      : makeTranslucent(StyleEditor::config.color.Playhead, 2));
+                      ? StyleEditor::getPlayheadColor()
+                      : makeTranslucent(StyleEditor::getPlayheadColor(), 2));
   const int x = moo_clock->now() / clockPerPx;
   drawPlayhead(painter, x, height, color, drawHead);
 }

--- a/src/editor/views/ViewHelper.cpp
+++ b/src/editor/views/ViewHelper.cpp
@@ -44,8 +44,8 @@ void drawPlayhead(QPainter &painter, qint32 x, qint32 height, QColor color,
 void drawCurrentPlayerPosition(QPainter &painter, MooClock *moo_clock,
                                int height, qreal clockPerPx, bool drawHead) {
   QColor color = (moo_clock->this_seek_caught_up() && moo_clock->now() > 0
-                      ? StyleEditor::getPlayheadColor()
-                      : makeTranslucent(StyleEditor::getPlayheadColor(), 2));
+                      ? StyleEditor::getActivePlayheadColor()
+                      : makeTranslucent(StyleEditor::getActivePlayheadColor(), 2));
   const int x = moo_clock->now() / clockPerPx;
   drawPlayhead(painter, x, height, color, drawHead);
 }

--- a/src/editor/views/ViewHelper.h
+++ b/src/editor/views/ViewHelper.h
@@ -87,4 +87,5 @@ extern void drawOctaveNumAlignBottomLeft(QPainter *painter, int x, int y,
                                          int num, int height, bool a);
 extern const int LEFT_LEGEND_WIDTH;
 extern QTransform worldTransform();
+
 #endif  // VIEWHELPER_H

--- a/src/styles/ptCollage/config.ini
+++ b/src/styles/ptCollage/config.ini
@@ -24,6 +24,7 @@ BarHigh=#FF0000
 
 [views]
 Playhead=#FFFFFF
+PlayheadRecording=#FFAAAA
 Cursor=#FFFFFF
 
 [measure]


### PR DESCRIPTION
Toggle recording mode with Ctrl + R (until a better shortcut is found)
Playhead will go pink/red when in recording mode, and that's the only time that the played MIDI events will be put into the song
Otherwise (in non-recording mode), you will only hear the sound of what you're playing.

Added PlayheadRecording to config.ini under [views]