### PR TITLE
Optimize drawing on high resolution

### DIFF
--- a/src/editor/views/KeyboardView.cpp
+++ b/src/editor/views/KeyboardView.cpp
@@ -432,7 +432,6 @@ double distance_to_mouse(const MouseEditState &mouse, const Interval &clock_int,
 
 void KeyboardView::paintEvent(QPaintEvent *event) {
   ++painted;
-  // if (painted > 10) return;
   QPainter painter(this);
   painter.fillRect(event->rect(), Qt::black);
 
@@ -454,6 +453,7 @@ void KeyboardView::paintEvent(QPaintEvent *event) {
     painter.fillRect(x, 0, 1, size().height(),
                      (isMeasureLine ? measureBrush : beatBrush));
   }
+
   // Draw key background
   QColor rootNoteColor = StyleEditor::config.color.KeyboardRootNote;
   QBrush rootNoteBrush = rootNoteColor;
@@ -465,10 +465,6 @@ void KeyboardView::paintEvent(QPaintEvent *event) {
   QBrush blackLeftInnerBrush = StyleEditor::config.color.KeyboardBlackLeftInner;
   QBrush black = StyleEditor::config.color.KeyboardBlack;
 
-  QLinearGradient gradient(0, 0, 1, 0);
-  gradient.setColorAt(0.5, rootNoteColor);
-  gradient.setColorAt(1, Qt::transparent);
-  gradient.setCoordinateMode(QGradient::ObjectMode);
   double pitchPerPx = m_client->editState().scale.pitchPerPx;
   const QList<int> &displayEdoList = Settings::DisplayEdo::get();
   int displayEdo = displayEdoList.size();

--- a/src/editor/views/KeyboardView.cpp
+++ b/src/editor/views/KeyboardView.cpp
@@ -336,8 +336,8 @@ static void drawCursor(const EditState &state, QPainter &painter,
   drawCursor(position, painter, color, username, uid);
 }
 
-void drawLeftPiano(QPainter &painter, int y, int h, const QColor &b,
-                   QColor *bInner) {
+void drawLeftPiano(QPainter &painter, int y, int h, const QBrush &b,
+                   QBrush *bInner) {
   painter.fillRect(0, y, LEFT_LEGEND_WIDTH, h, b);
   painter.fillRect(LEFT_LEGEND_WIDTH, y + 1, 1, h - 2, b);
   if (bInner) painter.fillRect(0, y, LEFT_LEGEND_WIDTH * 2 / 3, h, *bInner);
@@ -455,17 +455,18 @@ void KeyboardView::paintEvent(QPaintEvent *event) {
                      (isMeasureLine ? measureBrush : beatBrush));
   }
   // Draw key background
-  QColor rootNoteBrush = StyleEditor::config.color.KeyboardRootNote;
-  QColor whiteNoteBrush = StyleEditor::config.color.KeyboardWhiteNote;
-  QColor blackNoteBrush = StyleEditor::config.color.KeyboardBlackNote;
+  QColor rootNoteColor = StyleEditor::config.color.KeyboardRootNote;
+  QBrush rootNoteBrush = rootNoteColor;
+  QBrush whiteNoteBrush = StyleEditor::config.color.KeyboardWhiteNote;
+  QBrush blackNoteBrush = StyleEditor::config.color.KeyboardBlackNote;
 
-  QColor whiteLeftBrush = StyleEditor::config.color.KeyboardWhiteLeft;
-  QColor blackLeftBrush = StyleEditor::config.color.KeyboardBlackLeft;
-  QColor blackLeftInnerBrush = StyleEditor::config.color.KeyboardBlackLeftInner;
-  QColor black = StyleEditor::config.color.KeyboardBlack;
+  QBrush whiteLeftBrush = StyleEditor::config.color.KeyboardWhiteLeft;
+  QBrush blackLeftBrush = StyleEditor::config.color.KeyboardBlackLeft;
+  QBrush blackLeftInnerBrush = StyleEditor::config.color.KeyboardBlackLeftInner;
+  QBrush black = StyleEditor::config.color.KeyboardBlack;
 
   QLinearGradient gradient(0, 0, 1, 0);
-  gradient.setColorAt(0.5, rootNoteBrush);
+  gradient.setColorAt(0.5, rootNoteColor);
   gradient.setColorAt(1, Qt::transparent);
   gradient.setCoordinateMode(QGradient::ObjectMode);
   double pitchPerPx = m_client->editState().scale.pitchPerPx;
@@ -490,7 +491,7 @@ void KeyboardView::paintEvent(QPaintEvent *event) {
                                   s->start_vel};
     }
   for (int row = 0; true; ++row) {
-    QColor *brush, *leftBrush, *leftInnerBrush = nullptr;
+    QBrush *brush, *leftBrush, *leftInnerBrush = nullptr;
     // Start the backgrounds on an A just so that the key pattern lines up
     int a_above_max_key =
         (EVENTMAX_KEY / PITCH_PER_OCTAVE + 1) * PITCH_PER_OCTAVE;

--- a/src/editor/views/MeasureView.h
+++ b/src/editor/views/MeasureView.h
@@ -17,9 +17,11 @@ class MeasureView : public QWidget {
   Scale m_last_scale;
   MooClock *m_moo_clock;
   QFont m_label_font;
+  QFontMetrics m_label_font_metrics;
   std::unique_ptr<NotePreview> m_audio_note_preview;
   std::optional<int> m_focused_unit_no;
   std::optional<int> m_hovered_unit_no;
+  std::vector<std::optional<std::pair<QString, QPixmap>>> m_pinned_unit_labels;
   bool m_selection_mode;
   bool m_jump_to_unit_enabled;
 


### PR DESCRIPTION
Rendering was really slow on high resolution (~30fps empty project at 4k) because each frame the drawing loop creates a number of virtual canvases (QPixmaps) to allow for certain things to be grouped together and drawn in front of others. The pixmaps would be the same size as the piano roll panel to be drawn to (the measure ribbon, piano roll, or param edit), and it turns out that both creating & drawing the pixmaps were expensive, so this refactors a good chunk of code so that if a group of things needed to be 'remembered' and drawn later, they would be explicitly stored in some structs, and then a second code pass through the structs would paint them to the panel directly (instead of painting to a virtual canvas and then painting the virtual canvas).

For posterity these were the specific pixmaps that were removed:
1. The current unit pixmap on the piano roll
2. The pixmap on the piano roll for the alternate highlighted unit (e.g. if you're hovering a unit in the side menu, or if you pressed Ctrl+R and are hovering over a unit in the piano roll)
3. The pixmap for the piano on the LHS of the piano roll
4. The current unit pixmap on the param view

There was also the unit name labels which were harder to remove because they used the virtual canvas for compositing. This pixmap was isnteadchanged to be much smaller (just the size of the small text, vs. the full size of the panel) and cached so it wasn't recreated every frame. When I tested in HiDPI the FPS gain is still significant.

Also included some diff that changes some QColors to QBrushes outside vs. inside some loops per Ewan's suggestion, though not sure if that ended up affecting much.

In the end it's now over 55fps viewing the beginning measure of a heavy project.