### PR TITLE
Configurable draw scale for piano roll area

### DIFF
--- a/src/editor/Settings.cpp
+++ b/src/editor/Settings.cpp
@@ -315,7 +315,7 @@ void set(bool value) { return QSettings().setValue(KEY, value); }
 
 namespace DisplayScale {
 const char *KEY = "display_scale";
-int get() { return std::max(1, QSettings().value(KEY, 1).toInt()) * 0 + 1; }
+int get() { return std::max(1, QSettings().value(KEY, 1).toInt()); }
 void set(int value) { return QSettings().setValue(KEY, value); }
 }  // namespace DisplayScale
 

--- a/src/editor/Settings.cpp
+++ b/src/editor/Settings.cpp
@@ -3,7 +3,7 @@
 #include "ComboOptions.h"
 
 #ifndef PTCOLLAB_VERSION
-  #error Undefined PTCOLLAB_VERSION!
+#error Undefined PTCOLLAB_VERSION!
 #endif
 
 const QString BUFFER_LENGTH_KEY("buffer_length");
@@ -312,5 +312,11 @@ const char *KEY = "velocity_sensitivity";
 bool get() { return QSettings().value(KEY, true).toBool(); }
 void set(bool value) { return QSettings().setValue(KEY, value); }
 }  // namespace VelocitySensitivity
+
+namespace DisplayScale {
+const char *KEY = "display_scale";
+int get() { return std::max(1, QSettings().value(KEY, 1).toInt()) * 0 + 1; }
+void set(int value) { return QSettings().setValue(KEY, value); }
+}  // namespace DisplayScale
 
 }  // namespace Settings

--- a/src/editor/Settings.h
+++ b/src/editor/Settings.h
@@ -212,6 +212,10 @@ bool get();
 void set(bool);
 }  // namespace VelocitySensitivity
 
+namespace DisplayScale {
+int get();
+void set(int);
+}  // namespace DisplayScale
 }  // namespace Settings
 
 #endif  // SETTINGS_H

--- a/src/editor/SettingsDialog.cpp
+++ b/src/editor/SettingsDialog.cpp
@@ -48,6 +48,7 @@ void SettingsDialog::apply() {
       ui->selectPinnedUnitOnClickCheck->isChecked());
   Settings::StrictFollowSeek::set(ui->followSeekStrictCheck->isChecked());
   Settings::VelocitySensitivity::set(ui->velocitySensitivityCheck->isChecked());
+  Settings::DisplayScale::set(ui->displayScaleSpin->value());
   if (ui->alternateTuningCheck->isChecked()) {
     QList<int> rowDisplayPattern;
     for (char c : ui->rowDisplayEdit->text().toStdString()) {
@@ -96,6 +97,7 @@ void SettingsDialog::showEvent(QShowEvent *) {
   ui->selectPinnedUnitOnClickCheck->setChecked(
       Settings::MeasureViewClickToJumpUnit::get());
   ui->defaultVolumeSpin->setValue(Settings::NewUnitDefaultVolume::get());
+  ui->displayScaleSpin->setValue(Settings::DisplayScale::get());
   ui->recordMidiCheck->setChecked(Settings::RecordMidi::get());
   ui->followSeekStrictCheck->setChecked(Settings::StrictFollowSeek::get());
   ui->velocitySensitivityCheck->setChecked(

--- a/src/editor/SettingsDialog.ui
+++ b/src/editor/SettingsDialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">

--- a/src/editor/SettingsDialog.ui
+++ b/src/editor/SettingsDialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -195,6 +195,33 @@
           <string>Display pinned unit name labels</string>
          </property>
         </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QSpinBox" name="displayScaleSpin">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_6">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Display scaling</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QLabel" name="label_3">

--- a/src/editor/SettingsDialog.ui
+++ b/src/editor/SettingsDialog.ui
@@ -200,6 +200,9 @@
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QSpinBox" name="displayScaleSpin">
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
+           </property>
            <property name="minimum">
             <number>1</number>
            </property>
@@ -217,7 +220,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Display scaling</string>
+            <string>Editor pixel zoom</string>
            </property>
           </widget>
          </item>

--- a/src/editor/views/KeyboardView.h
+++ b/src/editor/views/KeyboardView.h
@@ -68,7 +68,7 @@ class KeyboardView : public QWidget {
   std::set<int> selectedUnitNos();
   void setHoveredUnitNo(std::optional<int>);
   void updateHoverSelect(QMouseEvent *event);
-  void updateStatePositions(EditState &, const QMouseEvent *, int leftPos);
+  void updateStatePositions(EditState &, const QMouseEvent *);
   QScrollArea *m_scrollarea;
   const pxtnService *m_pxtn;
   QElapsedTimer *m_timer;

--- a/src/editor/views/MeasureView.cpp
+++ b/src/editor/views/MeasureView.cpp
@@ -309,7 +309,8 @@ void MeasureView::paintEvent(QPaintEvent *raw_event) {
   QPaintEvent *e = &event;
   int height = worldTransform().inverted().map(QPoint(0, size().height())).y();
 
-  painter.fillRect(e->rect(), Qt::black);
+  QRect full_rect = e->rect().adjusted(-5, -5, 5, 5);
+  painter.fillRect(full_rect, Qt::black);
 
   // Draw white lines under background
   // TODO: Dedup with keyboardview
@@ -318,15 +319,15 @@ void MeasureView::paintEvent(QPaintEvent *raw_event) {
   int activeMeas = std::max(master->get_last_meas(), master->get_meas_num());
   qreal activeWidth =
       activeMeas * clockPerMeas / m_client->editState().scale.clockPerPx;
-  painter.fillRect(e->rect().left(), MEASURE_NUM_BLOCK_HEIGHT,
-                   e->rect().width(), RULER_HEIGHT,
+  painter.fillRect(full_rect.left(), MEASURE_NUM_BLOCK_HEIGHT,
+                   full_rect.width(), RULER_HEIGHT,
                    StyleEditor::config.color.MeasureExcluded);
   painter.fillRect(0, MEASURE_NUM_BLOCK_HEIGHT, activeWidth, RULER_HEIGHT,
                    StyleEditor::config.color.MeasureIncluded);
-  painter.fillRect(e->rect().left(),
+  painter.fillRect(full_rect.left(),
                    MEASURE_NUM_BLOCK_HEIGHT + RULER_HEIGHT + SEPARATOR_OFFSET,
-                   e->rect().width(), 1, StyleEditor::config.color.MeasureBeat);
-  int first_beat = e->rect().left() * m_client->editState().scale.clockPerPx /
+                   full_rect.width(), 1, StyleEditor::config.color.MeasureBeat);
+  int first_beat = full_rect.left() * m_client->editState().scale.clockPerPx /
                        master->get_beat_clock() -
                    1;
   std::optional<int> lastMeasureDraw;
@@ -376,7 +377,7 @@ void MeasureView::paintEvent(QPaintEvent *raw_event) {
 
   // Draw the unit edit rows
   for (uint i = 0; i < unit_draw_params_map.rows.size(); ++i) {
-    painter.fillRect(e->rect().left(), unit_edit_y(i), e->rect().width(),
+    painter.fillRect(full_rect.left(), unit_edit_y(i), full_rect.width(),
                      UNIT_EDIT_HEIGHT,
                      StyleEditor::config.color.MeasureUnitEdit);
     if (!unit_draw_params_map.rows[i].pinned_unit_id.has_value()) continue;

--- a/src/editor/views/MeasureView.cpp
+++ b/src/editor/views/MeasureView.cpp
@@ -274,9 +274,14 @@ void drawOngoingAction(const EditState &state,
 }
 
 QSize MeasureView::sizeHint() const {
-  return QSize(LEFT_LEGEND_WIDTH + one_over_last_clock(m_client->pxtn()) /
-                                       m_client->editState().scale.clockPerPx,
-               unit_edit_y(1 + m_client->editState().m_pinned_unit_ids.size()));
+  return worldTransform()
+      .mapRect(QRect(
+          QPoint(-LEFT_LEGEND_WIDTH, 0),
+          QPoint(
+              one_over_last_clock(m_client->pxtn()) /
+                  m_client->editState().scale.clockPerPx,
+              unit_edit_y(1 + m_client->editState().m_pinned_unit_ids.size()))))
+      .size();
 }
 
 void MeasureView::handleNewEditState(const EditState &) {

--- a/src/editor/views/MeasureView.cpp
+++ b/src/editor/views/MeasureView.cpp
@@ -525,8 +525,8 @@ void MeasureView::paintEvent(QPaintEvent *raw_event) {
             0.1 + 0.9 * clamp(dx - maxTextLabelWidth - 20, 0, 100) / 100;
       }
       painter.setOpacity(textLabelAlpha);
-      painter.drawPixmap(X_PADDING - SHADOW_WIDTH + viewport_pos.x(),
-                         unit_edit_y(i) - SHADOW_HEIGHT,
+      painter.drawPixmap(QPointF(X_PADDING - SHADOW_WIDTH + viewport_pos.x(),
+                                 unit_edit_y(i) - SHADOW_HEIGHT),
                          m_pinned_unit_labels[i].value().second);
     }
     painter.setOpacity(1);

--- a/src/editor/views/ParamView.cpp
+++ b/src/editor/views/ParamView.cpp
@@ -62,9 +62,13 @@ ParamView::ParamView(PxtoneClient *client, MooClock *moo_clock, QWidget *parent)
 }
 
 QSize ParamView::sizeHint() const {
-  return QSize(LEFT_LEGEND_WIDTH + one_over_last_clock(m_client->pxtn()) /
-                                       m_client->editState().scale.clockPerPx,
-               0x20);
+  return worldTransform()
+      .mapRect(
+          QRect(0, 0,
+                LEFT_LEGEND_WIDTH + one_over_last_clock(m_client->pxtn()) /
+                                        m_client->editState().scale.clockPerPx,
+                0x20))
+      .size();
 }
 
 constexpr double min_tuning = -1.0 / 24, max_tuning = 1.0 / 24;

--- a/src/editor/views/ParamView.cpp
+++ b/src/editor/views/ParamView.cpp
@@ -355,6 +355,7 @@ void ParamView::paintEvent(QPaintEvent *raw_event) {
   painter.setTransform(worldTransform());
   QPaintEvent e(worldTransform().inverted().mapRect(raw_event->rect()));
   QPaintEvent *event = &e;
+  int height = worldTransform().inverted().map(QPoint(0, size().height())).y();
   Interval clockBounds = {
       qint32(event->rect().left() * m_client->editState().scale.clockPerPx) -
           WINDOW_BOUND_SLACK,
@@ -375,14 +376,14 @@ void ParamView::paintEvent(QPaintEvent *raw_event) {
     int x = master->get_beat_clock() * beat /
             m_client->editState().scale.clockPerPx;
     if (x > event->rect().right()) break;
-    painter.fillRect(x, 0, 1, size().height(),
+    painter.fillRect(x, 0, 1, height,
                      (isMeasureLine ? measureBrush : beatBrush));
   }
 
   // Draw param background
   for (int i = 0; i < NUM_BACKGROUND_GAPS - 1; ++i) {
-    int this_y = BACKGROUND_GAPS[i] * size().height() / 0x80;
-    int next_y = BACKGROUND_GAPS[i + 1] * size().height() / 0x80;
+    int this_y = BACKGROUND_GAPS[i] * height / 0x80;
+    int next_y = BACKGROUND_GAPS[i + 1] * height / 0x80;
     painter.fillRect(event->rect().left(), this_y + 1, event->rect().width(),
                      std::max(1, next_y - this_y - 2), *GAP_COLORS[i]);
   }
@@ -421,11 +422,11 @@ void ParamView::paintEvent(QPaintEvent *raw_event) {
   auto handleLastEvent = [&](const Event &last, const Event &curr,
                              int unit_no) {
     if (current_kind != EVENTKIND_VOICENO)
-      drawLastEvent(painter, current_kind, height(), last, curr, clockPerPx,
+      drawLastEvent(painter, current_kind, height, last, curr, clockPerPx,
                     colors[unit_no], unit_no - current_unit_no,
                     m_client->pxtn()->Unit_Num());
     else if (unit_no == current_unit_no)
-      drawLastVoiceNoEvent(painter, height(), last, curr, clockPerPx,
+      drawLastVoiceNoEvent(painter, height, last, curr, clockPerPx,
                            colors[unit_no], m_client->pxtn());
   };
 
@@ -463,7 +464,7 @@ void ParamView::paintEvent(QPaintEvent *raw_event) {
     drawOngoingEdit(painter, state.mouse_edit_state, current_kind,
                     m_client->quantizeClock(
                         quantizeXOptions()[state.m_quantize_clock_idx].second),
-                    clockPerPx, pitchPerPx, height(), alphaMultiplier,
+                    clockPerPx, pitchPerPx, height, alphaMultiplier,
                     selectionAlphaMultiplier, unit_no - current_unit_no);
   };
 
@@ -489,14 +490,14 @@ void ParamView::paintEvent(QPaintEvent *raw_event) {
 
   if (m_client->clipboard()->kindIsCopied(current_kind))
     drawExistingSelection(painter, m_client->editState().mouse_edit_state,
-                          clockPerPx, size().height(), 1);
+                          clockPerPx, height, 1);
   drawOngoingEdit(painter, m_client->editState().mouse_edit_state, current_kind,
-                  m_client->quantizeClock(), clockPerPx, pitchPerPx, height(),
-                  1, 1, 0);
+                  m_client->quantizeClock(), clockPerPx, pitchPerPx, height, 1,
+                  1, 0);
 
-  drawLastSeek(painter, m_client, height(), false);
-  drawCurrentPlayerPosition(painter, m_moo_clock, height(), clockPerPx, false);
-  drawRepeatAndEndBars(painter, m_moo_clock, clockPerPx, height());
+  drawLastSeek(painter, m_client, height, false);
+  drawCurrentPlayerPosition(painter, m_moo_clock, height, clockPerPx, false);
+  drawRepeatAndEndBars(painter, m_moo_clock, clockPerPx, height);
 
   // Draw cursors
   for (const auto &[uid, remote_state] : m_client->remoteEditStates()) {
@@ -516,7 +517,7 @@ void ParamView::paintEvent(QPaintEvent *raw_event) {
       else
         color = StyleEditor::config.color.Cursor;
       drawCursor(state, painter, color, remote_state.user, uid, current_kind,
-                 height());
+                 height);
     }
   }
   {
@@ -524,16 +525,17 @@ void ParamView::paintEvent(QPaintEvent *raw_event) {
     auto it = m_client->remoteEditStates().find(m_client->following_uid());
     if (it != m_client->remoteEditStates().end()) my_username = it->second.user;
     drawCursor(m_client->editState(), painter, StyleEditor::config.color.Cursor,
-               my_username, m_client->following_uid(), current_kind, height());
+               my_username, m_client->following_uid(), current_kind, height);
   }
 }
 
 // TODO: DEDUP
 static void updateStatePositions(EditState &edit_state,
                                  const QMouseEvent *event,
-                                 EVENTKIND current_kind, int height) {
+                                 EVENTKIND current_kind, const QSize &size) {
   MouseEditState &state = edit_state.mouse_edit_state;
   QPointF mouse_pos = worldTransform().inverted().map(event->localPos());
+  int height = worldTransform().inverted().map(QPoint(0, size.height())).y();
   state.current_clock =
       std::max(0., mouse_pos.x() * edit_state.scale.clockPerPx);
   bool snap = event->modifiers() & Qt::ControlModifier;
@@ -717,7 +719,7 @@ void ParamView::mouseReleaseEvent(QMouseEvent *event) {
           }
         }
         s.mouse_edit_state.type = MouseEditState::Type::Nothing;
-        updateStatePositions(s, event, kind, height());
+        updateStatePositions(s, event, kind, size());
       },
       false);
 }
@@ -732,9 +734,7 @@ void ParamView::mouseMoveEvent(QMouseEvent *event) {
       paramOptions()[m_client->editState().current_param_kind_idx()].second;
   if (!m_client->isFollowing())
     m_client->changeEditState(
-        [&](auto &s) {
-          updateStatePositions(s, event, current_kind, height());
-        },
+        [&](auto &s) { updateStatePositions(s, event, current_kind, size()); },
         true);
   event->ignore();
 }

--- a/src/editor/views/ViewHelper.cpp
+++ b/src/editor/views/ViewHelper.cpp
@@ -242,8 +242,9 @@ void drawOctaveNumAlignBottomLeft(QPainter *painter, int x, int y, int num,
 }
 
 const int LEFT_LEGEND_WIDTH = 40;
+
 QTransform worldTransform() {
-  return QTransform().translate(LEFT_LEGEND_WIDTH, 0);
+  return QTransform().scale(2, 2).translate(LEFT_LEGEND_WIDTH, 0);
 }
 
 const int WINDOW_BOUND_SLACK = 32;

--- a/src/editor/views/ViewHelper.cpp
+++ b/src/editor/views/ViewHelper.cpp
@@ -244,7 +244,8 @@ void drawOctaveNumAlignBottomLeft(QPainter *painter, int x, int y, int num,
 const int LEFT_LEGEND_WIDTH = 40;
 
 QTransform worldTransform() {
-  return QTransform().scale(2, 2).translate(LEFT_LEGEND_WIDTH, 0);
+  int scale = Settings::DisplayScale::get();
+  return QTransform().scale(scale, scale).translate(LEFT_LEGEND_WIDTH, 0);
 }
 
 const int WINDOW_BOUND_SLACK = 32;

--- a/src/protocol/Hello.cpp
+++ b/src/protocol/Hello.cpp
@@ -6,7 +6,7 @@
 // communicate with each other
 constexpr char CLIENT_HELLO[] = "PTCOLLAB_CLIENT_HELLO";
 constexpr char SERVER_HELLO[] = "PTCOLLAB_SERVER_HELLO";
-const qint64 PROTOCOL_VERSION = 9;
+const qint64 PROTOCOL_VERSION = 10;
 
 ClientHello::ClientHello(const QString &username)
     : hello(CLIENT_HELLO), version(PROTOCOL_VERSION), m_username(username) {}


### PR DESCRIPTION
Add ability to draw everything in the edit area (measure / pinned units, piano roll, param edits) at a configurable pixel scale (whole number from 1 to 5). This should make it so that on hi-dpi the pinned units and measure ribbon aren't tiny.

A lot of this was just getting places where we used to get a size / position and changing it so that the appropriate transform was applied / un-applied before / after.