### PR TITLE
Stop audio on shutdown

### DIFF
--- a/src/editor/PxtoneClient.cpp
+++ b/src/editor/PxtoneClient.cpp
@@ -88,6 +88,11 @@ PxtoneClient::PxtoneClient(pxtnService *pxtn,
           &PxtoneClient::processRemoteAction);
 }
 
+PxtoneClient::~PxtoneClient() {
+  m_audio->stop();
+  m_pxtn_device->setPlaying(false);
+}
+
 void PxtoneClient::loadDescriptor(pxtnDescriptor &desc) {
   // An empty desc is interpreted as an empty file so we don't error.
   m_controller->loadDescriptor(desc);

--- a/src/editor/PxtoneClient.h
+++ b/src/editor/PxtoneClient.h
@@ -59,6 +59,7 @@ class PxtoneClient : public QObject {
   PxtoneClient(pxtnService *pxtn, ConnectionStatusLabel *connection_status,
 
                QObject *parent = nullptr);
+  ~PxtoneClient();
   void applyAction(const std::list<Action::Primitive> &);
   void sendAction(const ClientAction &);
   void removeCurrentUnit();


### PR DESCRIPTION
Fixes a SIGABRT (on Linux?) during shutdown, where not stopping the audio during the PxtoneClient's destruction lets through one more tick of audio output with invalid parameters, which causes an assertion failure in PulseAudio:

> Assertion 's' failed at ../src/pulse/stream.c:1705, function pa_stream_writable_size(). Aborting.

---

As debugged on Discord.