### PR TITLE
Style-related cleanups

### DIFF
--- a/src/editor/EditorWindow.cpp
+++ b/src/editor/EditorWindow.cpp
@@ -1041,24 +1041,6 @@ void EditorWindow::hostDirectly(std::optional<QString> filename,
   m_client->connectToLocalServer(m_server, username);
 }
 
-bool EditorWindow::eventFilter(QObject *watched, QEvent *event) {
-  switch (event->type()) {
-    case QEvent::Show:
-      // https://doc.qt.io/qt-5/qshowevent.html
-      // Spontaneous QShowEvents are sent by the window system after the window
-      // is shown, as well as when it's reshown after being iconified. We only
-      // want this to trigger when Qt sends it, which is right before it becomes
-      // visible.
-      if (!event->spontaneous()) {
-        QWidget *w = qobject_cast<QWidget *>(watched);
-        if (w) StyleEditor::setTitleBar(w);
-      }
-      return false;
-    default:
-      return false;
-  }
-}
-
 bool EditorWindow::saveToFile(QString filename, bool warnOnError) {
 #ifdef _WIN32
   FILE *f_raw;

--- a/src/editor/EditorWindow.h
+++ b/src/editor/EditorWindow.h
@@ -55,7 +55,6 @@ class EditorWindow : public QMainWindow {
   void keyPressEvent(QKeyEvent* event) override;
   void keyReleaseEvent(QKeyEvent* event) override;
   void closeEvent(QCloseEvent* event) override;
-  bool eventFilter(QObject *watched, QEvent *event) override;
   KeyboardView* m_keyboard_view;
   MeasureView* m_measure_view;
   pxtnService m_pxtn;

--- a/src/editor/StyleEditor.h
+++ b/src/editor/StyleEditor.h
@@ -30,6 +30,30 @@ void setTitleBar(QWidget *w) noexcept;
 bool tryLoadStyle(const QString &styleName);
 const std::shared_ptr<QPixmap> measureImages();
 std::shared_ptr<NoteBrush const> noteBrush(int i);
+
+class EventFilter : public QObject {
+  Q_OBJECT
+ public:
+  bool eventFilter(QObject *watched, QEvent *event) {
+    switch (event->type()) {
+      case QEvent::Show:
+        // https://doc.qt.io/qt-5/qshowevent.html
+        // Spontaneous QShowEvents are sent by the window system after the
+        // window is shown, as well as when it's reshown after being iconified.
+        // We only want this to trigger when Qt sends it, which is right before
+        // it becomes visible.
+        if (!event->spontaneous()) {
+          QWidget *w = qobject_cast<QWidget *>(watched);
+          if (w) setTitleBar(w);
+        }
+
+        return false;
+      default:
+        return false;
+    }
+  }
+};
+
 struct Config {
  private:
   Config() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,13 @@ int main(int argc, char *argv[]) {
   a->setApplicationName("ptcollab");
   a->setApplicationVersion(Settings::Version::string());
 
+  // Remove "?" button on dialogs; this is a Windows-only feature and
+  // goes unused in ptcollab. It shouldn't be the default...
+  a->setAttribute(Qt::AA_DisableWindowContextHelpButton);
+
+  StyleEditor::EventFilter f;
+  a->installEventFilter(&f);
+
   QCommandLineParser parser;
   parser.setApplicationDescription("A collaborative pxtone editor");
   parser.addHelpOption();
@@ -180,7 +187,6 @@ int main(int argc, char *argv[]) {
         qWarning() << "No styles were loaded. Falling back on system style.";
     }
     EditorWindow w;
-    a->installEventFilter(&w);
     w.show();
     if (startServerImmediately)
       w.hostDirectly(filename, host, port, recording_file, username);

--- a/src/styles/dark/dark.qss
+++ b/src/styles/dark/dark.qss
@@ -54,6 +54,7 @@ VolumeMeterFrame {
 QPushButton,
 QComboBox,
 QLineEdit,
+QTextEdit,
 QSpinBox {
 	padding: 0.2em;
 	border: 0.1em solid palette(button);
@@ -63,6 +64,7 @@ QSpinBox {
 QPushButton:disabled,
 QComboBox:disabled,
 QLineEdit:disabled,
+QTextEdit:disabled,
 QSpinBox:disabled,
 QHeaderView::section:disabled,
 QLabel:disabled {
@@ -72,9 +74,11 @@ QLabel:disabled {
 QPushButton:disabled,
 QComboBox:disabled,
 QLineEdit:disabled,
+QTextEdit:disabled,
 QSpinBox:disabled,
 QHeaderView::section:disabled {
 	border-color: palette(bright-text);
+	color: #9a9a9a; /* This is what the text color roughly equates to when grayed out. */
 }
 
 QPushButton {
@@ -94,12 +98,14 @@ QTabBar::tab {
 }
 
 QLineEdit,
+QTextEdit,
 QSpinBox {
 	border: 0.1em solid palette(button);
 	background-color: palette(base);
 }
 
 QLineEdit:disabled,
+QTextEdit:disabled,
 QSpinBox:disabled {
 	border: 0.1em solid palette(bright-text);
 }


### PR DESCRIPTION
add style for QTextEdit, move event filter installation earlier in app init, remove '?' button on dialogs