### PR TITLE
Add short/exe name to desktop file keywords

### DIFF
--- a/res/ptcollab.desktop
+++ b/res/ptcollab.desktop
@@ -5,5 +5,5 @@ Comment=pxtone collab: multiplayer music editor
 Exec=ptcollab %f
 Icon=ptcollab
 Categories=Audio;AudioVideo;AudioVideoEditing;
-Keywords=music;chiptune;pxtone;
+Keywords=ptcollab;music;chiptune;pxtone;
 Terminal=false


### PR DESCRIPTION
So searching for the repo name bring up the application in launchers that only use a basic substring search.

Before:
![screenshot20230318_190151896](https://user-images.githubusercontent.com/23431373/226143713-a215ca12-12c7-40fa-aa46-373f79ef1f71.png)

After:
![screenshot20230318_233444373](https://user-images.githubusercontent.com/23431373/226143718-74a8ec4e-d2ac-44af-b350-b41c8c16a424.png)
