### PR TITLE
CI: ubuntu 18.04 -> 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - { name: "Windows", os: windows-latest, make: nmake, qt_arch: win64_msvc2019_64, target_arch: amd64 }
           - { name: "Windows 32-bit", os: windows-latest, make: nmake, qt_arch: win32_msvc2019, target_arch: x86 }
           - { name: "macOS", os: macos-latest, make: "make -j2", qt_arch: clang_64 }
-          - { name: "Ubuntu", os: ubuntu-18.04, make: "make -j2", qt_arch: gcc_64 }
+          - { name: "Ubuntu", os: ubuntu-20.04, make: "make -j2", qt_arch: gcc_64 }
       fail-fast: false
 
     name: ${{ matrix.config.name }}


### PR DESCRIPTION
18.04 builders have been deprecated:
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/