### PR TITLE
add translations to sidebar view headers, add qtbase translation loading

### DIFF
--- a/src/editor/sidemenu/DelayEffectModel.cpp
+++ b/src/editor/sidemenu/DelayEffectModel.cpp
@@ -111,13 +111,13 @@ QVariant DelayEffectModel::headerData(int section, Qt::Orientation orientation,
     if (role == Qt::DisplayRole) {
       switch (DelayEffectColumn(section)) {
         case DelayEffectColumn::Group:
-          return "G";
+          return tr("G");
         case DelayEffectColumn::Unit:
-          return "Unit";
+          return tr("Unit");
         case DelayEffectColumn::Frequency:
-          return "Freq.";
+          return tr("Freq.");
         case DelayEffectColumn::Rate:
-          return "Ratio";
+          return tr("Ratio");
       }
     }
     if (role == Qt::ToolTipRole) {

--- a/src/editor/sidemenu/DelayEffectModel.cpp
+++ b/src/editor/sidemenu/DelayEffectModel.cpp
@@ -111,25 +111,30 @@ QVariant DelayEffectModel::headerData(int section, Qt::Orientation orientation,
     if (role == Qt::DisplayRole) {
       switch (DelayEffectColumn(section)) {
         case DelayEffectColumn::Group:
-          return tr("G");
+          return tr("G",
+                    "Group (abbreviated if necessary, shown in table header)");
         case DelayEffectColumn::Unit:
-          return tr("Unit");
+          return tr("Unit",
+                    "Unit (abbreviated if necessary, shown in table header)");
         case DelayEffectColumn::Frequency:
-          return tr("Freq.");
+          return tr(
+              "Freq.",
+              "Frequency (abbreviated if necessary, shown in table header)");
         case DelayEffectColumn::Rate:
-          return tr("Ratio");
+          return tr("Ratio",
+                    "Ratio (abbreviated if necessary, shown in table header)");
       }
     }
     if (role == Qt::ToolTipRole) {
       switch (DelayEffectColumn(section)) {
         case DelayEffectColumn::Group:
-          return tr("Group");
+          return tr("Group", "Group (full word, shown in tooltip)");
         case DelayEffectColumn::Unit:
-          return tr("Unit");
+          return tr("Unit", "Unit (full word, shown in tooltip)");
         case DelayEffectColumn::Frequency:
-          return tr("Frequency");
+          return tr("Frequency", "Frequency (full word, shown in tooltip)");
         case DelayEffectColumn::Rate:
-          return tr("Ratio");
+          return tr("Ratio", "Ratio (full word, shown in tooltip)");
       }
     }
   }

--- a/src/editor/sidemenu/OverdriveEffectModel.cpp
+++ b/src/editor/sidemenu/OverdriveEffectModel.cpp
@@ -97,11 +97,11 @@ QVariant OverdriveEffectModel::headerData(int section,
     if (role == Qt::DisplayRole) {
       switch (OverdriveEffectColumn(section)) {
         case OverdriveEffectColumn::Group:
-          return "G";
+          return tr("G");
         case OverdriveEffectColumn::Cut:
-          return "Cut";
+          return tr("Cut");
         case OverdriveEffectColumn::Amp:
-          return "Amp.";
+          return tr("Amp.");
       }
     }
     if (role == Qt::ToolTipRole) {

--- a/src/editor/sidemenu/OverdriveEffectModel.cpp
+++ b/src/editor/sidemenu/OverdriveEffectModel.cpp
@@ -97,21 +97,26 @@ QVariant OverdriveEffectModel::headerData(int section,
     if (role == Qt::DisplayRole) {
       switch (OverdriveEffectColumn(section)) {
         case OverdriveEffectColumn::Group:
-          return tr("G");
+          return tr("G",
+                    "Group (abbreviated if necessary, shown in table header)");
         case OverdriveEffectColumn::Cut:
-          return tr("Cut");
+          return tr("Cut",
+                    "Cut (abbreviated if necessary, shown in table header)");
         case OverdriveEffectColumn::Amp:
-          return tr("Amp.");
+          return tr("Amp.",
+                    "Amplification (abbreviated if necessary, shown in table "
+                    "header)");
       }
     }
     if (role == Qt::ToolTipRole) {
       switch (OverdriveEffectColumn(section)) {
         case OverdriveEffectColumn::Group:
-          return tr("Group");
+          return tr("Group", "Group (full word, shown in tooltip)");
         case OverdriveEffectColumn::Cut:
-          return tr("Cut");
+          return tr("Cut", "Cut (full word, shown in tooltip)");
         case OverdriveEffectColumn::Amp:
-          return tr("Amplification");
+          return tr("Amplification",
+                    "Amplification (full word, shown in tooltip)");
       }
     }
   }

--- a/src/editor/sidemenu/UnitListModel.cpp
+++ b/src/editor/sidemenu/UnitListModel.cpp
@@ -156,7 +156,8 @@ QVariant UnitListModel::headerData(int section, Qt::Orientation orientation,
         case UnitListColumn::Pinned:
           break;
         case UnitListColumn::Name:
-          return tr("Name");
+          return tr("Name",
+                    "Name (abbreviated if necessary, shown in table header)");
       }
     }
     if (role == Qt::DecorationRole) {
@@ -180,7 +181,7 @@ QVariant UnitListModel::headerData(int section, Qt::Orientation orientation,
         case UnitListColumn::Pinned:
           return tr("Pinned");
         case UnitListColumn::Name:
-          return tr("Name");
+          return tr("Name", "Name (full word, shown in tooltip)");
       }
     }
   }

--- a/src/editor/sidemenu/UnitListModel.cpp
+++ b/src/editor/sidemenu/UnitListModel.cpp
@@ -156,7 +156,7 @@ QVariant UnitListModel::headerData(int section, Qt::Orientation orientation,
         case UnitListColumn::Pinned:
           break;
         case UnitListColumn::Name:
-          return "Name";
+          return tr("Name");
       }
     }
     if (role == Qt::DecorationRole) {

--- a/src/editor/sidemenu/UserListModel.cpp
+++ b/src/editor/sidemenu/UserListModel.cpp
@@ -42,7 +42,7 @@ QVariant UserListModel::data(const QModelIndex &index, int role) const {
         if (user->second.last_ping.has_value()) {
           int ping = static_cast<int>(user->second.last_ping.value());
           if (ping > 1000) return QString("%1s").arg(ping / 1000);
-          return ping + tr("ms");
+          return QString("%1ms").arg(ping);
         }
         return "";
       case UserListModel::Column::Name:

--- a/src/editor/sidemenu/UserListModel.cpp
+++ b/src/editor/sidemenu/UserListModel.cpp
@@ -40,9 +40,9 @@ QVariant UserListModel::data(const QModelIndex &index, int role) const {
         return user->first;
       case UserListModel::Column::Ping:
         if (user->second.last_ping.has_value()) {
-          int ping = user->second.last_ping.value();
+          int ping = static_cast<int>(user->second.last_ping.value());
           if (ping > 1000) return QString("%1s").arg(ping / 1000);
-          return QString("%1ms").arg(ping);
+          return ping + tr("ms");
         }
         return "";
       case UserListModel::Column::Name:
@@ -62,7 +62,7 @@ QVariant UserListModel::headerData(int section, Qt::Orientation orientation,
         case UserListModel::Column::Ping:
           return QVariant();
         case UserListModel::Column::Name:
-          return "Name";
+          return tr("Name");
       }
     }
   }

--- a/src/editor/sidemenu/WoiceListModel.cpp
+++ b/src/editor/sidemenu/WoiceListModel.cpp
@@ -146,9 +146,11 @@ QVariant WoiceListModel::headerData(int section, Qt::Orientation orientation,
         case WoiceListColumn::BeatFit:
           break;
         case WoiceListColumn::Key:
-          return tr("Key");
+          return tr("Key",
+                    "Key (abbreviated if necessary, shown in table header)");
         case WoiceListColumn::Name:
-          return tr("Name");
+          return tr("Name",
+                    "Name (abbreviated if necessary, shown in table header)");
       }
     }
     if (role == Qt::DecorationRole) {
@@ -169,9 +171,9 @@ QVariant WoiceListModel::headerData(int section, Qt::Orientation orientation,
         case WoiceListColumn::BeatFit:
           return tr("Beat fit");
         case WoiceListColumn::Key:
-          return tr("Key");
+          return tr("Key", "Key (full word, shown in tooltip)");
         case WoiceListColumn::Name:
-          return tr("Name");
+          return tr("Name", "Name (full word, shown in tooltip)");
       }
     }
   }

--- a/src/editor/sidemenu/WoiceListModel.cpp
+++ b/src/editor/sidemenu/WoiceListModel.cpp
@@ -146,9 +146,9 @@ QVariant WoiceListModel::headerData(int section, Qt::Orientation orientation,
         case WoiceListColumn::BeatFit:
           break;
         case WoiceListColumn::Key:
-          return "Key";
+          return tr("Key");
         case WoiceListColumn::Name:
-          return "Name";
+          return tr("Name");
       }
     }
     if (role == Qt::DecorationRole) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]) {
   a->setOrganizationDomain("ptweb.me");
   a->setApplicationName("ptcollab");
   a->setApplicationVersion(Settings::Version::string());
-  QTranslator translator, /*qtTranslator,*/ baseTranslator;
+  QTranslator translator, baseTranslator;
   QString language = Settings::Language::get();
   if (language == "default") {
     if (!translator.load(qApp->applicationDirPath() + "/translation.qm"))
@@ -64,15 +64,17 @@ int main(int argc, char *argv[]) {
     translator.load(":/i18n/" + language);
   a->installTranslator(&translator);
 
-  // adapted from https://stackoverflow.com/a/31557808/16570148
-  //  if (qtTranslator.load(translator.language(), "qt", "_",
-  //                        QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
-  //    a->installTranslator(&qtTranslator);
-  // Doesn't seem to do anything? Leaving this here in case there are issues
   if (baseTranslator.load(
           "qtbase_" + language,
           QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
     a->installTranslator(&baseTranslator);
+
+  // adapted from https://stackoverflow.com/a/31557808/16570148
+  //  QTranslator qtTranslator;
+  //  if (qtTranslator.load(translator.language(), "qt", "_",
+  //                        QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+  //    a->installTranslator(&qtTranslator);
+  // Doesn't seem to do anything? Leaving this here in case there are issues
 
   // Remove "?" button on dialogs; this is a Windows-only feature and
   // goes unused in ptcollab. It shouldn't be the default...

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <QApplication>
 #include <QCommandLineParser>
+#include <QLibraryInfo>
 #include <QTranslator>
 
 #include "editor/EditorWindow.h"
@@ -54,7 +55,7 @@ int main(int argc, char *argv[]) {
   a->setOrganizationDomain("ptweb.me");
   a->setApplicationName("ptcollab");
   a->setApplicationVersion(Settings::Version::string());
-  QTranslator translator;
+  QTranslator translator, /*qtTranslator,*/ baseTranslator;
   QString language = Settings::Language::get();
   if (language == "default") {
     if (!translator.load(qApp->applicationDirPath() + "/translation.qm"))
@@ -62,6 +63,16 @@ int main(int argc, char *argv[]) {
   } else
     translator.load(":/i18n/" + language);
   a->installTranslator(&translator);
+
+  // adapted from https://stackoverflow.com/a/31557808/16570148
+  //  if (qtTranslator.load(translator.language(), "qt", "_",
+  //                        QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+  //    a->installTranslator(&qtTranslator);
+  // Doesn't seem to do anything? Leaving this here in case there are issues
+  if (baseTranslator.load(
+          "qtbase_" + language,
+          QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+    a->installTranslator(&baseTranslator);
 
   // Remove "?" button on dialogs; this is a Windows-only feature and
   // goes unused in ptcollab. It shouldn't be the default...


### PR DESCRIPTION
qtbase translation allows qmessagebox buttons ("standard buttons", as also seen in dialogs and stuff) to be translated. and probably a bunch of other stuff

translations to sidebar is self-explanatory; it looked like these translations were explicitly omitted (right next to instances where the title was translated just a few lines away, except as a tooltip). if this was intended, i'm not sure what the effect was meant to be but i think it should be translated either way. if not, oopsies