### PR TITLE
EditorWindow: Make Quit option trigger window close events

### DIFF
--- a/src/editor/EditorWindow.cpp
+++ b/src/editor/EditorWindow.cpp
@@ -284,7 +284,7 @@ EditorWindow::EditorWindow(QWidget *parent)
   connect(ui->actionShortcuts, &QAction::triggered, m_shortcuts_dialog,
           &QDialog::exec);
   connect(ui->actionExit, &QAction::triggered,
-          []() { QApplication::instance()->quit(); });
+          []() { QApplication::closeAllWindows(); });
   connect(ui->actionAbout, &QAction::triggered, [=]() {
     QMessageBox::about(this, "About",
                        tr("Multiplayer pxtone music editor. Special "


### PR DESCRIPTION
Currently, selecting the "Quit" menu option will trigger an instant shutdown of the application via `QCoreApplication::quit()`, which acts akin to instantly returning from main.
Doing it this way doesn't trigger any `QWindow::closeEvent`s by design though, so our "unsaved changes" check on the `EditorWindow` is bypassed.

Making the button work that way is confusing for users: There is no warning about unsaved changes, backups do not get cleaned up, and on the next startup it is treated like an unexpected termination - all because a menu option was used instead of the OS' window controls.

Instead of `QCoreApplication::quit()`, call `QApplication::closeAllWindows()`. This has the same effect of shutting down the application, but it's achieved by sending close events to all windows instead, which is exactly what we need. In fact, the documentation of this method[1] even points out that it's ideal for hooking up to an `Exit` menu option.

[1]: At least for Qt 5.15 LTS, https://doc.qt.io/qt-5/qapplication.html#closeAllWindows