### PR TITLE
test fix macos CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           submodules: recursive
 
       - name: Install Qt5
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.QT_VERSION }}
           arch: ${{ matrix.config.qt_arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
               # https://doc.qt.io/qt-5/supported-platforms.html#macos
               "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
 
-              -DCMAKE_OSX_ARCHITECTURES="arm64"
+              "-DCMAKE_OSX_ARCHITECTURES=arm64"
 
               # We cannot ship libraries from Homebrew, because they target a higher macOS version than Qt, which produces a borked build
               "-DENABLE_SYSTEM_LIBS=OFF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,8 @@ jobs:
               # https://doc.qt.io/qt-5/supported-platforms.html#macos
               "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
 
+              -DCMAKE_OSX_ARCHITECTURES="arm64"
+
               # We cannot ship libraries from Homebrew, because they target a higher macOS version than Qt, which produces a borked build
               "-DENABLE_SYSTEM_LIBS=OFF"
             )


### PR DESCRIPTION
this might work

doc for qt 6: https://doc.qt.io/qt-6/macos.html#architectures

what i can find as it pertains to qt 5: https://www.qt.io/blog/qt-on-apple-silicon
> Some patches already went into Qt 5, so Qt 5.15.4 and above should build and run by passing -device-option QMAKE_APPLE_DEVICE_ARCHS=arm64 to configure. Note that this configuration is not tested in CI, and is hence unsupported at this point.
