### PR TITLE
Avoid out of bounds access when event is referencing non-existent unit

### DIFF
--- a/src/editor/views/KeyboardView.cpp
+++ b/src/editor/views/KeyboardView.cpp
@@ -732,6 +732,9 @@ void KeyboardView::paintEvent(QPaintEvent *raw_event) {
        e = e->next) {
     // if (e->clock > clockBounds.end) break;
     int unit_no = e->unit_no;
+    if (unit_no >= drawStates.size()) {
+      continue;
+    }
     DrawState &state = drawStates[unit_no];
     switch (e->kind) {
       case EVENTKIND_ON:

--- a/src/editor/views/ParamView.cpp
+++ b/src/editor/views/ParamView.cpp
@@ -446,6 +446,10 @@ void ParamView::paintEvent(QPaintEvent *raw_event) {
     if (e->kind != current_kind) continue;
     int unit_no = e->unit_no;
 
+    if (unit_no >= lastEvents.size()) {
+      continue;
+    }
+
     Event curr{e->clock, e->value};
     if (unit_no == current_unit_no)
       current_unit_events.push_back(lastEvents[unit_no]);


### PR DESCRIPTION
Fixes #122 

Current approach is to just bail out if we detect that the unit doesn't exist.
We might want to do something more graceful, like at least show an error message, or maybe
even create a dummy unit.

But I'm not sure which approach to take.